### PR TITLE
capture and emit the actual session config

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,11 +147,11 @@ Cloud.prototype.start = function(fn){
       var browser = wd.remote('ondemand.saucelabs.com', 80, self.user, self.key);
       self.emit('init', conf);
 
-      browser.init(conf, function(){
+      browser.init(conf, function(_, id, session) {
         debug('open %s', self._url);
-        self.emit('start', conf);
+        self.emit('start', session);
 
-        browser.get(self._url, function(err){
+        browser.get(self._url, function(err) {
           if (err) {
             debug('browser.get(%s) error: %s', self.url, err);
             return done(err);
@@ -174,7 +174,7 @@ Cloud.prototype.start = function(fn){
             }
 
             debug('results %j', res);
-            self.emit('end', conf, res);
+            self.emit('end', session, res);
             var passed = !res.error && 0 == res.failures;
             browser.sauceJobStatus(passed, function(err) {
               debug('setting sauce job status: %s', passed ? 'pass' : 'fail');


### PR DESCRIPTION
`cloud.browser` is only desired capabilities. You can simply request `firefox` to run on the latest version, but currently you don't know what version and platform it resolved to. This updates the emit events to use the actual capabilties object, which has this information and much more.

capbilities object has stuff like:

``` javascript
{ 
    rotatable: false,
    takesScreenshot: true,
    acceptSslCerts: true,
    cssSelectorsEnabled: true,
    javascriptEnabled: true,
    nativeEvents: false,
    databaseEnabled: true,
    locationContextEnabled: true,
    platform: 'WINDOWS',
    browserName: 'firefox',
    'webdriver.remote.sessionid': 'eeb3bb78a9d947c0974dbf580eda32c2',
    hasMetadata: true,
    version: '40.0.2',
    applicationCacheEnabled: true,
    webStorageEnabled: true,
    handlesAlerts: true
}
```

Example log output from my gulp task, where I don't specify versions

```
[22:31:44] init googlechrome linux
[22:31:44] init firefox win7
[22:31:47] start chrome 45.0.2454.85 Linux
[22:31:50] success chrome 45.0.2454.85 Linux in 1.459s
[22:31:51] start firefox 40.0.2 WINDOWS
[22:31:54] success firefox 40.0.2 WINDOWS in 1.471s
```
